### PR TITLE
prov/rxm: fix address comparison to remove duplicate connections

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -537,7 +537,7 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		break;
 	case RXM_CM_CONNECTING:
 		/* simultaneous connections */
-		cmp = ofi_addr_cmp(&rxm_prov, &peer_addr.sa, &peer->addr.sa);
+		cmp = ofi_addr_cmp(&rxm_prov, &peer_addr.sa, &ep->addr.sa);
 		if (cmp < 0) {
 			/* let our request finish */
 			rxm_reject_connreq(ep, cm_entry,
@@ -558,9 +558,7 @@ rxm_process_connreq(struct rxm_ep *ep, struct rxm_eq_cm_entry *cm_entry)
 		break;
 	case RXM_CM_ACCEPTING:
 	case RXM_CM_CONNECTED:
-		/* peer reset and lost previous connection state */
-		rxm_close_conn(conn);
-		break;
+		goto put;
 	default:
 		assert(0);
 		break;


### PR DESCRIPTION
The address comparison to determine whether to reject or keep a duplicate
connection was incorrect and falsely identifying too many loopback
connections. The address to compare against should be the local EP's
address, not the peer's address.

This fix exposes an issue with the reject/close path which was not being
taken before. A race condition during simultaneous connections was
occurring where both sides sent a connection request. One side received
a connection request, accepted, and closed its outgoing connection.
However, the connection request had already been received by the peer,
causing the peer to incorrectly identify that connection as a lost
connection, causing send failures for any outstanding sends on that
active connection.

This patch could potentially cause issues in how lost connections are
managed, but testing to date has not shown any issues... yet...

Signed-off-by: aingerson <alexia.ingerson@intel.com>