### PR TITLE
github/workflows: update tested ubuntu versions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,15 +1,15 @@
 name: Nightly Coverity Scan
-on:
-  schedule:
-  # Every night, at midnight
-  - cron: '0 0 * * *'
+# on:
+#   schedule:
+#   # Every night, at midnight
+#   - cron: '0 0 * * *'
+on: [push, pull_request]
 env:
   APT_PACKAGES: >-
     abi-compliance-checker
     abi-dumper
     build-essential
     debhelper
-    dh-systemd
     fakeroot
     gcc
     git
@@ -21,7 +21,7 @@ env:
     ninja-build
     pandoc
     pkg-config
-    python
+    python-is-python3
     rpm
     sparse
     valgrind
@@ -41,7 +41,7 @@ env:
   RDMA_CORE_VERSION: v34.1
 jobs:
   coverity:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies (Linux)
         run: |

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,7 +6,6 @@ env:
     abi-dumper
     build-essential
     debhelper
-    dh-systemd
     fakeroot
     gcc
     git
@@ -18,7 +17,7 @@ env:
     ninja-build
     pandoc
     pkg-config
-    python
+    python-is-python3
     rpm
     sparse
     valgrind
@@ -43,8 +42,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
+          - ubuntu-22.04
         cc:
           - gcc
           - clang


### PR DESCRIPTION
ubuntu-18.04 runners are deprecated, move to ubuntu-20.04 and ubuntu-2022.04

Signed-off-by: Stephen Oost <stephen.oost@intel.com>